### PR TITLE
Initialize dfnum with the max size value

### DIFF
--- a/include/boost/graph/dominator_tree.hpp
+++ b/include/boost/graph/dominator_tree.hpp
@@ -356,7 +356,8 @@ namespace boost {
 
     const IndexMap indexMap = get(vertex_index, g);
 
-    std::vector<VerticesSizeType> dfnum(numOfVertices, 0);
+    std::vector<VerticesSizeType> dfnum(
+      numOfVertices, std::numeric_limits<VerticesSizeType>::max());
     TimeMap dfnumMap(make_iterator_property_map(dfnum.begin(), indexMap));
 
     std::vector<Vertex> parent(numOfVertices,


### PR DESCRIPTION
The previous default value of 0 will, if not updated, pass the "skip unreachable nodes" in the dominator visitor. This leads to the pred_map containing a forest instead of a tree, and the forest won't contain a correct tree either (we can't filter the output to get what we want).

This change attempts to solve this by making the second half of the check succeed "n > numVertices".